### PR TITLE
A few changes to support omitting `USER` in bouncer commands in reply threads

### DIFF
--- a/user.py
+++ b/user.py
@@ -42,7 +42,12 @@ class UserLookup:
             # Simply verify by attempting to cast to an int. If it doesn't raise an error, return it
             # NOTE: This requires the ID to be first word, after the command
             check_id = content.split()[0]
-            return int(check_id)
+
+            # Match at least 4 integers to not confuse user ids with regular numbers
+            # User ids are snowflakes. Based on the snowflake format (https://discord.com/developers/docs/reference#snowflakes)
+            # Any account created after the first millisecond of 2015 will have an id of at least 4194304 (1 << 22)
+            # Which is 7 integers, so this practically shouldn't ever miss anyone.
+            return int(check_id) if len(check_id) >= 4 else None
         except (IndexError, ValueError):
             return None
 

--- a/utils.py
+++ b/utils.py
@@ -37,8 +37,14 @@ def check_roles(user: discord.Member, valid_roles: list[int]) -> bool:
             return True
     return False
 
-# Since usernames can have spaces, first check if it's a username, otherwise just cut off first word as normal
-def parse_message(message: str, username: str) -> str:
+# Removes a user mention from a message
+def parse_message(message: str, username: str, username_in_message: bool = True) -> str:
+    # If the username isn't in the message, just strip the command from it
+    if not username_in_message:
+        return strip_words(message, 1)
+
+    # Otherwise strip the command and username
+    # Since usernames can have spaces, first check if it's a username, otherwise just cut off first word as normal
     txt = " ".join(message.split()[1:])
     if txt.startswith(username):
         return txt[len(username)+1:]


### PR DESCRIPTION
## Summary

These changes are to support using the reply thread user in reply threads rather than needing to ping the user in bouncer commands.

Bouncer PR: https://github.com/aquova/bouncer/pull/11

---

Commands always looked like
```
$command USER <ARGS>
```

but now they might look like
```
$command <ARGS>
```

in a reply thread - the user is taken by looking up the thread id in the db and seeing if it corresponds to a user.

To support this, two things are needed:

* User reference stripping:
   * Now that commands don't always have a user in them, sometimes only one word needs to be stripped (the command), not two (the command and the user reference).
* User reference parsing:
  * Some bouncer commands can now look like `$command NUMBER ARGS`, i.e. the `$remove` and `$edit` to choose a note to operate on.
  * Now that commands don't always have a user in them, `$command NUMBER` makes the code think number is the user id.
  * Easiest way to fix this was to only take numbers that are at least 4 digits long. This'll still break if a user has 1000 notes, but I don't think that's very likely.
  * Is there a better way to fix this?

Let me know if you want any changes!

## Testing

* I ran every bouncer command which calls these methods, and it didn't break and worked as expected.
* No bot besides bouncer calls `parse_message` (as far as I could tell), so the new parameter won't break other bots.